### PR TITLE
Upc2c issue 52

### DIFF
--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -1267,8 +1267,15 @@ static void IVIEHelper(raw_ostream &OS, QualType Ty) {
       OS << "{}";
       return;
     }
-  } else if (Ty->isArrayType()) { // Recurse on element type
-    Ty = Ty->getAsArrayTypeUnsafe()->getElementType();
+  } else if (Ty->isArrayType()) {
+    // Only ConstantArray is possible in this context
+    const ConstantArrayType *Arr = cast<ConstantArrayType>(Ty->getAsArrayTypeUnsafe());
+    if (Arr->getSize().getZExtValue()) { // Recurse on element type
+      Ty = Arr->getElementType();
+    } else { // non-C99 0-length array
+      OS << "{}";
+      return;
+    }
   } else {
     OS << 0;
     return;


### PR DESCRIPTION
Please consider this replacement implementation of StmtPrinter::VisitImplicitValueInitExpr() which resolves [issue #52](https://github.com/Intrepid/upc2c/issues/52) in the upc2c tracker.

-Paul
