### PR TITLE
Emit parens around GCCAsmStmt input and output expressions

### DIFF
--- a/lib/AST/StmtPrinter.cpp
+++ b/lib/AST/StmtPrinter.cpp
@@ -478,8 +478,9 @@ void StmtPrinter::VisitGCCAsmStmt(GCCAsmStmt *Node) {
     }
 
     VisitStringLiteral(Node->getOutputConstraintLiteral(i));
-    OS << " ";
+    OS << " (";
     Visit(Node->getOutputExpr(i));
+    OS << ')';
   }
 
   // Inputs
@@ -497,8 +498,9 @@ void StmtPrinter::VisitGCCAsmStmt(GCCAsmStmt *Node) {
     }
 
     VisitStringLiteral(Node->getInputConstraintLiteral(i));
-    OS << " ";
+    OS << " (";
     Visit(Node->getInputExpr(i));
+    OS << ')';
   }
 
   // Clobbers


### PR DESCRIPTION
Please consider pulling this small change which fixes backend compilation failures on the UTS tests in the Berkeley UPC test suite.  The only change is to place parens around the input and output expressions, without which gcc-4.7.0 as the backend was complaining:

```
upcc: error compiling translated C code: 
brg_sha1.trans.c: In function 'sha1_hash':
brg_sha1.trans.c:337:56: error: expected '(' before '__v'
brg_sha1.trans.c: In function 'sha1_end':
brg_sha1.trans.c:360:48: error: expected '(' before '__v'
```
