### PR TITLE
Proposed fix for upc2c issue #78 on ppc64

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1628,7 +1628,10 @@ ASTContext::getTypeInfoImpl(const Type *T) const {
   case Type::Pointer: {
     if (cast<PointerType>(T)->getPointeeType().getQualifiers().hasShared()) {
       Width = (LangOpts.UPCPhaseBits + LangOpts.UPCThreadBits + LangOpts.UPCAddrBits);
-      Align = Target->getTypeAlign(Target->getInt64Type());
+      if (LangOpts.UPCPtsRep)
+        Align = Target->getTypeAlign(Target->getInt64Type()); // Packed PTS
+      else
+        Align = Target->getTypeAlign(Target->getIntPtrType()); // Struct PTS
     } else {
       unsigned AS = getTargetAddressSpace(cast<PointerType>(T)->getPointeeType());
       Width = Target->getPointerWidth(AS);


### PR DESCRIPTION
This commit corrects the reported alignment for the struct PTS on
a target with 32-bit pointers.  It should be the same as a 32-bit
integer, not a 64-bit one as was the case previously.

This did not show on x86_64, where the ILP32 ABI (x86) requires only
4-byte alignment for both 32- and 64-bit integers.  However on PPC64
both the LP64 and ILP32 ABIs specify 8-byte alignment of 8-byte
integers, leading to a mismatch between clang-upc and the C code in
UPCR.