### PR TITLE
Port UPC runtime to aarch64

### DIFF
--- a/runtime/libupc/smp/upc_sync.h
+++ b/runtime/libupc/smp/upc_sync.h
@@ -56,6 +56,9 @@ PA-RISC		SYNC			none reqd. */
 #elif defined (hppa)
 #define GUPCR_WRITE_FENCE() asm __volatile__ ("SYNC":::"memory")
 #define GUPCR_READ_FENCE() asm __volatile__ ("":::"memory")
+#elif defined (__aarch64__)
+#define GUPCR_WRITE_FENCE() asm __volatile__ ("dmb ishst":::"memory")
+#define GUPCR_READ_FENCE() asm __volatile__ ("dmb ishld":::"memory")
 #else
 # error "No memory fence  operations provided for this cpu."
 #endif


### PR DESCRIPTION
By defining the memory fences, this commit effectively "ports" the UPC runtime to AARCH64 (aka ARMV8).

Depends on updates to config.guess and config.sub:
  https://github.com/Intrepid/llvm-upc/pull/14
  https://github.com/Intrepid/clang-upc/pull/82