### PR TITLE
Fix GCC toolchain search on Solaris

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1521,17 +1521,20 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
   if (TargetTriple.getOS() == llvm::Triple::Solaris) {
     switch(TargetTriple.getArch()) {
     case llvm::Triple::sparc:
+    case llvm::Triple::sparcv9:
       LibDirs.append(begin(SolarisSPARCLibDirs), end(SolarisSPARCLibDirs));
       TripleAliases.append(begin(SolarisSPARCTriples), end(SolarisSPARCTriples));
       break;
     case llvm::Triple::x86:
+    case llvm::Triple::x86_64:
       LibDirs.append(begin(SolarisX86LibDirs), end(SolarisX86LibDirs));
       TripleAliases.append(begin(SolarisX86Triples), end(SolarisX86Triples));
       break;
     default:
+      llvm_unreachable("Unsupported architecture");
       break;
     }
-    goto handle_default_triple;
+    return;
   }
 
   switch (TargetTriple.getArch()) {
@@ -1648,8 +1651,6 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
     // triple.
     break;
   }
-
- handle_default_triple:
 
   // Always append the drivers target triple to the end, in case it doesn't
   // match any of our aliases.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1510,16 +1510,28 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
 
   // Solaris.
   static const char *const SolarisSPARCLibDirs[] = {"/gcc"};
-  static const char *const SolarisSPARCTriples[] = {"sparc-sun-solaris2.11",
-                                                    "i386-pc-solaris2.11"};
+  static const char *const SolarisSPARCTriples[] = {"sparc-sun-solaris2.11"};
+
+  static const char *const SolarisX86LibDirs[] = {"/gcc"};
+  static const char *const SolarisX86Triples[] = {"i386-pc-solaris2.11"};
 
   using std::begin;
   using std::end;
 
   if (TargetTriple.getOS() == llvm::Triple::Solaris) {
-    LibDirs.append(begin(SolarisSPARCLibDirs), end(SolarisSPARCLibDirs));
-    TripleAliases.append(begin(SolarisSPARCTriples), end(SolarisSPARCTriples));
-    return;
+    switch(TargetTriple.getArch()) {
+    case llvm::Triple::sparc:
+      LibDirs.append(begin(SolarisSPARCLibDirs), end(SolarisSPARCLibDirs));
+      TripleAliases.append(begin(SolarisSPARCTriples), end(SolarisSPARCTriples));
+      break;
+    case llvm::Triple::x86:
+      LibDirs.append(begin(SolarisX86LibDirs), end(SolarisX86LibDirs));
+      TripleAliases.append(begin(SolarisX86Triples), end(SolarisX86Triples));
+      break;
+    default:
+      break;
+    }
+    goto handle_default_triple;
   }
 
   switch (TargetTriple.getArch()) {
@@ -1636,6 +1648,8 @@ bool Generic_GCC::GCCInstallationDetector::getBiarchSibling(Multilib &M) const {
     // triple.
     break;
   }
+
+ handle_default_triple:
 
   // Always append the drivers target triple to the end, in case it doesn't
   // match any of our aliases.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -2206,9 +2206,6 @@ void Generic_GCC::GCCInstallationDetector::scanLibDirForGCCTripleSolaris(
     StringRef VersionText = llvm::sys::path::filename(LI->getName());
     GCCVersion CandidateVersion = GCCVersion::Parse(VersionText);
 
-    if (CandidateVersion.Major != -1) // Filter obviously bad entries.
-      if (!CandidateGCCInstallPaths.insert(LI->getName()).second)
-        continue; // Saw this path before; no need to look at it again.
     if (CandidateVersion.isOlderThan(4, 1, 1))
       continue;
     if (CandidateVersion <= Version)
@@ -2216,6 +2213,9 @@ void Generic_GCC::GCCInstallationDetector::scanLibDirForGCCTripleSolaris(
 
     GCCInstallPath =
         LibDir + "/" + VersionText.str() + "/lib/gcc/" + CandidateTriple.str();
+    if (CandidateVersion.Major != -1) // Filter obviously bad entries.
+      if (!CandidateGCCInstallPaths.insert(GCCInstallPath).second)
+        continue; // Saw this path before; no need to look at it again.
     if (!D.getVFS().exists(GCCInstallPath))
       continue;
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -2239,6 +2239,20 @@ void Generic_GCC::GCCInstallationDetector::scanLibDirForGCCTripleSolaris(
     GCCInstallPath += "/" + Version.Text;
     GCCParentLibPath = GCCInstallPath + "/../../../../";
 
+    switch (TargetArch.getArch()) {
+    case llvm::Triple::x86:
+    case llvm::Triple::sparc:
+      break;
+    case llvm::Triple::x86_64:
+      GCCInstallPath += "/amd64";
+      break;
+    case llvm::Triple::sparcv9:
+      GCCInstallPath += "/sparcv9";
+      break;
+    default:
+      llvm_unreachable("Unsupported architecture");
+    }
+
     IsValid = true;
   }
 }


### PR DESCRIPTION
This PR is to resolve Intrepid/llvm-upc#18
Specifically, this fixes the logic to locate the proper gcc toolchain on Solaris (which is broken in the Clang 3.8 release).